### PR TITLE
Expose syncscope parameter for atomic add/sub

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,8 +13,7 @@ jobs:
     strategy:
       matrix:
         julia-version:
-          - '1'
-          - '1.6'
+          - '1.10'
           - 'nightly'
       fail-fast: false
     name: Test Julia ${{ matrix.julia-version }}
@@ -36,8 +35,7 @@ jobs:
     strategy:
       matrix:
         julia-version:
-          - '1'
-          - '1.6'
+          - '1.10'
           - 'nightly'
       fail-fast: false
     steps:

--- a/LocalPreferences.toml
+++ b/LocalPreferences.toml
@@ -1,2 +1,0 @@
-[LLVM]
-libLLVMExtra = "/home/pxlth/.julia/scratchspaces/929cbde3-209d-540e-8aea-75f648917ca0/build/lib/libLLVMExtra-16.so"

--- a/LocalPreferences.toml
+++ b/LocalPreferences.toml
@@ -1,0 +1,2 @@
+[LLVM]
+libLLVMExtra = "/home/pxlth/.julia/scratchspaces/929cbde3-209d-540e-8aea-75f648917ca0/build/lib/libLLVMExtra-16.so"

--- a/Project.toml
+++ b/Project.toml
@@ -1,13 +1,13 @@
 name = "UnsafeAtomicsLLVM"
 uuid = "d80eeb9a-aca5-4d75-85e5-170c8b632249"
 authors = ["Takafumi Arakaki <aka.tkf@gmail.com> and contributors"]
-version = "0.1.5"
+version = "0.2.0"
 
 [deps]
 LLVM = "929cbde3-209d-540e-8aea-75f648917ca0"
 UnsafeAtomics = "013be700-e6cd-48c3-b4a1-df204f14c38f"
 
 [compat]
-LLVM = "6, 7, 8"
+LLVM = "8.1"
 UnsafeAtomics = "0.2"
-julia = "1.6"
+julia = "1.10"

--- a/src/atomics.jl
+++ b/src/atomics.jl
@@ -256,6 +256,21 @@ end
 
 const AtomicRMWBinOpVal = Union{(Val{binop} for (_, _, binop) in binoptable)...}
 
+# Syncscopes.
+const SyncscopeSystem = Val{:system}()
+const SyncscopeSingleThread = Val{:singlethread}()
+# AMDGPU-specific to enable fast hardware floating-point atomics:
+# https://llvm.org/docs/AMDGPUUsage.html#memory-scopes
+const SyncscopeAgent = Val{:agent}()
+
+const Syncscopes = Union{
+    typeof(SyncscopeSystem),
+    typeof(SyncscopeSingleThread),
+    typeof(SyncscopeAgent)}
+
+# LLVM API accepts string literal as a syncscope argument.
+@inline syncscope_to_string(::Type{Val{S}}) where S = string(S)
+
 @generated function llvm_atomic_op(
     binop::AtomicRMWBinOpVal,
     ptr::LLVMPtr{T,A},
@@ -289,6 +304,39 @@ const AtomicRMWBinOpVal = Union{(Val{binop} for (_, _, binop) in binoptable)...}
             ret!(builder, rv)
         end
 
+        call_function(llvm_f, T, Tuple{LLVMPtr{T,A},T}, :ptr, :val)
+    end
+end
+
+@generated function llvm_atomic_op(
+    binop::AtomicRMWBinOpVal,
+    ptr::LLVMPtr{T,A},
+    val::T,
+    order::LLVMOrderingVal,
+    syncscope::Syncscopes,
+) where {T,A}
+    @dispose ctx = Context() begin
+        T_val = convert(LLVMType, T)
+        T_ptr = convert(LLVMType, ptr)
+
+        T_typed_ptr = LLVM.PointerType(T_val, A)
+        llvm_f, _ = create_function(T_val, [T_ptr, T_val])
+
+        @dispose builder = IRBuilder() begin
+            entry = BasicBlock(llvm_f, "entry")
+            position!(builder, entry)
+
+            typed_ptr = bitcast!(builder, parameters(llvm_f)[1], T_typed_ptr)
+            rv = atomic_rmw!(
+                builder,
+                _valueof(binop()),
+                typed_ptr,
+                parameters(llvm_f)[2],
+                _valueof(order()),
+                syncscope_to_string(syncscope))
+
+            ret!(builder, rv)
+        end
         call_function(llvm_f, T, Tuple{LLVMPtr{T,A},T}, :ptr, :val)
     end
 end
@@ -359,8 +407,11 @@ for (opname, op, llvmop) in binoptable
             ::$(typeof(op)),
             x::$T,
             order::AtomicOrdering,
+            syncscope::Syncscopes = SyncscopeSystem,
         )
-            old = llvm_atomic_op($(Val(llvmop)), ptr, x, llvm_from_julia_ordering(order))
+            old = syncscope isa typeof(SyncscopeSystem) ?
+                llvm_atomic_op($(Val(llvmop)), ptr, x, llvm_from_julia_ordering(order)) :
+                llvm_atomic_op($(Val(llvmop)), ptr, x, llvm_from_julia_ordering(order), syncscope)
             return old => $op(old, x)
         end
     end

--- a/src/atomics.jl
+++ b/src/atomics.jl
@@ -248,11 +248,9 @@ const binoptable = [
     (:umin, min, LLVM.API.LLVMAtomicRMWBinOpUMin),
     (:fadd, +, LLVM.API.LLVMAtomicRMWBinOpFAdd),
     (:fsub, -, LLVM.API.LLVMAtomicRMWBinOpFSub),
+    (:fmax, max, LLVM.API.LLVMAtomicRMWBinOpFMax),
+    (:fmin, min, LLVM.API.LLVMAtomicRMWBinOpFMin),
 ]
-if VERSION ≥ v"1.10-"
-    push!(binoptable, (:fmax, max, LLVM.API.LLVMAtomicRMWBinOpFMax))
-    push!(binoptable, (:fmin, min, LLVM.API.LLVMAtomicRMWBinOpFMin))
-end
 
 const AtomicRMWBinOpVal = Union{(Val{binop} for (_, _, binop) in binoptable)...}
 

--- a/src/internal.jl
+++ b/src/internal.jl
@@ -26,7 +26,7 @@ mapop(::typeof(UnsafeAtomics.right)) = right
     x,
     order::Ordering,
     syncscope::Val{S} = Val(:system),
-) where {OP<:Union{typeof(+),typeof(-)}, S} =
+) where {OP<:Union{typeof(+),typeof(-)},S} =
     atomic_pointermodify(ptr, mapop(op), x, Val{julia_ordering_name(order)}(), syncscope)
 
 @inline UnsafeAtomics.cas!(

--- a/src/internal.jl
+++ b/src/internal.jl
@@ -21,10 +21,13 @@ mapop(::typeof(UnsafeAtomics.right)) = right
     atomic_pointermodify(ptr, mapop(op), x, Val{julia_ordering_name(order)}())
 
 @inline UnsafeAtomics.modify!(
-    ptr::LLVMPtr, op::OP, x, order::Ordering, syncscope::Syncscopes = SyncscopeSystem,
-) where {OP <: Union{typeof(+), typeof(-)}} = atomic_pointermodify(
-    ptr, mapop(op), x, Val{julia_ordering_name(order)}(), syncscope,
-)
+    ptr::LLVMPtr,
+    op::OP,
+    x,
+    order::Ordering,
+    syncscope::Syncscopes = SyncscopeSystem,
+) where {OP<:Union{typeof(+),typeof(-)}} =
+    atomic_pointermodify(ptr, mapop(op), x, Val{julia_ordering_name(order)}(), syncscope)
 
 @inline UnsafeAtomics.cas!(
     ptr::LLVMPtr,

--- a/src/internal.jl
+++ b/src/internal.jl
@@ -25,7 +25,7 @@ mapop(::typeof(UnsafeAtomics.right)) = right
     op::OP,
     x,
     order::Ordering,
-    syncscope::Val{S} = Val{:system}(),
+    syncscope::Val{S} = Val(:system),
 ) where {OP<:Union{typeof(+),typeof(-)}, S} =
     atomic_pointermodify(ptr, mapop(op), x, Val{julia_ordering_name(order)}(), syncscope)
 

--- a/src/internal.jl
+++ b/src/internal.jl
@@ -20,6 +20,12 @@ mapop(::typeof(UnsafeAtomics.right)) = right
 @inline UnsafeAtomics.modify!(ptr::LLVMPtr, op::OP, x, order::Ordering) where {OP} =
     atomic_pointermodify(ptr, mapop(op), x, Val{julia_ordering_name(order)}())
 
+@inline UnsafeAtomics.modify!(
+    ptr::LLVMPtr, op::OP, x, order::Ordering, syncscope::Syncscopes = SyncscopeSystem,
+) where {OP <: Union{typeof(+), typeof(-)}} = atomic_pointermodify(
+    ptr, mapop(op), x, Val{julia_ordering_name(order)}(), syncscope,
+)
+
 @inline UnsafeAtomics.cas!(
     ptr::LLVMPtr,
     expected,

--- a/src/internal.jl
+++ b/src/internal.jl
@@ -25,8 +25,8 @@ mapop(::typeof(UnsafeAtomics.right)) = right
     op::OP,
     x,
     order::Ordering,
-    syncscope::Syncscopes = SyncscopeSystem,
-) where {OP<:Union{typeof(+),typeof(-)}} =
+    syncscope::Val{S} = Val{:system}(),
+) where {OP<:Union{typeof(+),typeof(-)}, S} =
     atomic_pointermodify(ptr, mapop(op), x, Val{julia_ordering_name(order)}(), syncscope)
 
 @inline UnsafeAtomics.cas!(

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -66,7 +66,7 @@ function test_explicit_ordering(T::Type = UInt)
                     op,
                     x2,
                     seq_cst,
-                    Val{:system}(),
+                    Val(:system),
                 ) === (x1 => op(x1, x2))
                 @test xs[1] === op(x1, x2)
 
@@ -76,7 +76,7 @@ function test_explicit_ordering(T::Type = UInt)
                     op,
                     x2,
                     seq_cst,
-                    Val{:singlethread}(),
+                    Val(:singlethread),
                 ) === (x1 => op(x1, x2))
                 @test xs[1] === op(x1, x2)
             end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -62,12 +62,12 @@ function test_explicit_ordering(T::Type = UInt)
             if (op == +) || (op == -)
                 xs[1] = x1
                 @test UnsafeAtomics.modify!(ptr, op, x2, seq_cst, Val(:system)) ===
-                    (x1 => op(x1, x2))
+                      (x1 => op(x1, x2))
                 @test xs[1] === op(x1, x2)
 
                 xs[1] = x1
                 @test UnsafeAtomics.modify!(ptr, op, x2, seq_cst, Val(:singlethread)) ===
-                    (x1 => op(x1, x2))
+                      (x1 => op(x1, x2))
                 @test xs[1] === op(x1, x2)
             end
         end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -61,23 +61,13 @@ function test_explicit_ordering(T::Type = UInt)
             # Test syncscopes.
             if (op == +) || (op == -)
                 xs[1] = x1
-                @test UnsafeAtomics.modify!(
-                    ptr,
-                    op,
-                    x2,
-                    seq_cst,
-                    Val(:system),
-                ) === (x1 => op(x1, x2))
+                @test UnsafeAtomics.modify!(ptr, op, x2, seq_cst, Val(:system)) ===
+                    (x1 => op(x1, x2))
                 @test xs[1] === op(x1, x2)
 
                 xs[1] = x1
-                @test UnsafeAtomics.modify!(
-                    ptr,
-                    op,
-                    x2,
-                    seq_cst,
-                    Val(:singlethread),
-                ) === (x1 => op(x1, x2))
+                @test UnsafeAtomics.modify!(ptr, op, x2, seq_cst, Val(:singlethread)) ===
+                    (x1 => op(x1, x2))
                 @test xs[1] === op(x1, x2)
             end
         end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -29,18 +29,6 @@ function check_default_ordering(T::Type)
             xs[1] = x1
             @test rmw(ptr, x2) === x1
             @test xs[1] === op(x1, x2)
-
-            # Test syncscopes.
-            if (op == +) || (op == -)
-                @info "!!!!!!!!!!!!!!!!!!!"
-                xs[1] = x1
-                @test UnsafeAtomics.modify!(ptr, op, x2, seq_cst, UnsafeAtomicsLLVM.Internal.SyncscopeSystem) === (x1 => op(x1, x2))
-                @test xs[1] === op(x1, x2)
-
-                xs[1] = x1
-                @test UnsafeAtomics.modify!(ptr, op, x2, seq_cst, UnsafeAtomicsLLVM.Internal.SyncscopeSingleThread) === (x1 => op(x1, x2))
-                @test xs[1] === op(x1, x2)
-            end
         end
     end
 end
@@ -69,6 +57,29 @@ function test_explicit_ordering(T::Type = UInt)
             xs[1] = x1
             @test rmw(ptr, x2, acquire) === x1
             @test xs[1] === op(x1, x2)
+
+            # Test syncscopes.
+            if (op == +) || (op == -)
+                xs[1] = x1
+                @test UnsafeAtomics.modify!(
+                    ptr,
+                    op,
+                    x2,
+                    seq_cst,
+                    UnsafeAtomicsLLVM.Internal.SyncscopeSystem,
+                ) === (x1 => op(x1, x2))
+                @test xs[1] === op(x1, x2)
+
+                xs[1] = x1
+                @test UnsafeAtomics.modify!(
+                    ptr,
+                    op,
+                    x2,
+                    seq_cst,
+                    UnsafeAtomicsLLVM.Internal.SyncscopeSingleThread,
+                ) === (x1 => op(x1, x2))
+                @test xs[1] === op(x1, x2)
+            end
         end
     end
 end
@@ -76,7 +87,6 @@ end
 @testset "UnsafeAtomicsLLVM" begin
     @testset for T in inttypes
         check_default_ordering(T)
-        # test_explicit_ordering(T)
-        break
+        test_explicit_ordering(T)
     end
 end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -66,7 +66,7 @@ function test_explicit_ordering(T::Type = UInt)
                     op,
                     x2,
                     seq_cst,
-                    UnsafeAtomicsLLVM.Internal.SyncscopeSystem,
+                    Val{:system}(),
                 ) === (x1 => op(x1, x2))
                 @test xs[1] === op(x1, x2)
 
@@ -76,7 +76,7 @@ function test_explicit_ordering(T::Type = UInt)
                     op,
                     x2,
                     seq_cst,
-                    UnsafeAtomicsLLVM.Internal.SyncscopeSingleThread,
+                    Val{:singlethread}(),
                 ) === (x1 => op(x1, x2))
                 @test xs[1] === op(x1, x2)
             end


### PR DESCRIPTION
- Expose syncscope parameter for atomic add/sub.
  Applying syncscope `"agent"` to atomic add/sub enabled fast hardware atomics on AMDGPU targets.
  The plan is to also have AMDGPU extension for Atomix which will expose `syncscope` for `@atomic` macro for `+` `-` ops.
- Bump minor version to 0.2.0.
- Bump LLVM to 8.1
- Bump min Julia to 1.10.